### PR TITLE
feat: add td lint rules to boilerplate output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][]
+### Added
+- [td linting rules](https://github.com/tomdaniels/td-eslint-config)
 
 ## [1.3.2][] - 2018-08-31
 ### Added

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -8,7 +8,8 @@
     "start": "node ./src/server.js",
     "test": "jest",
     "watch": "nodemon ./src/server.js",
-    "version": "version-changelog CHANGELOG.md && changelog-verify CHANGELOG.md && git add CHANGELOG.md"
+    "version": "version-changelog CHANGELOG.md && changelog-verify CHANGELOG.md && git add CHANGELOG.md",
+    "lint": "./node_modules/.bin/eslint './src/**/*.js'"
   },
   "author": "Tom Daniels",
   "license": "ISC",
@@ -33,6 +34,13 @@
     "version-changelog": "^3.1.0",
     "sinon": "^6.1.4",
     "supertest": "^3.1.0",
-    "jest": "22.4.1"
+    "jest": "22.4.1",
+    "eslint-config-td-eslint-config": "^1.1.0",
+    "prettier": "^1.14.2"
+  },
+  "eslintConfig": {
+    "extends": [
+      "td-eslint-config"
+    ]
   }
 }


### PR DESCRIPTION
### This is a

- [ ] Breaking change
- [x] New feature
- [ ] Bugfix

### I have

- [x] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [ ] Updated [`README.md`](README.md)
- [x] Made sure the dependencies in [`package.json`](package.json) are up to date

### What's changed

- Added [td linting rules](https://github.com/tomdaniels/td-eslint-config) to boilerplate output
